### PR TITLE
Rework `Project` and `Version` structures

### DIFF
--- a/r2c_isg/structures/README.md
+++ b/r2c_isg/structures/README.md
@@ -1,0 +1,85 @@
+## R2C `0.4.x` Data Structures
+
+### Overview
+
+At a high level, an R2C ISG `Dataset` contains a list of `Project` objects which
+in turn contain lists of `Version` objects. While different registries give
+these objects different names (eg, Pypi's "project" and "release" vs. Github's
+"repo" and "commit"), the fundamental relationships are the same.
+
+The `0.4.x` base `Project` and `Version` classes are intended to be lightweight
+and flexible, and are then extended and customized for each registry. The
+registry-specific classes are as follows:
+
+- Github: `GithubRepo` and `GithubCommit`
+- Npm: `NpmPackage` and `NpmVersion`
+- Pypi: `PypiProject` and `PypiRelease`
+
+These structures provide the following functionality: 
+
+- A `metadata` dictionary for storing data from authoritative sources, namely
+data obtained from a registry api. `keep([attrs...])` and `drop([attrs...])`
+utility functions are also provided to allow users to easily trim metadata down
+to only desired fields.
+- A `data` dictionary for storing data from non-authoritative sources such as
+files, weblists, and user-provided data.
+- A `get_ids()` function which returns a dictionary of name:value pairs of
+unique project/version identifiers. Typically, unique identifiers include `name`
+and `url` for projects and `version` or `commit` for versions. This function is
+used for project/version comparison, and must be implemented by each registry's
+structures.
+- _(Project-only)_ A `to_inputset()` function to generate a list of input set
+items. This function's implementation is unique to each registry.
+- Each registry structure may also add its own custom properties. For example,
+`GithubRepo` provides `full_name` and `url` properties.
+
+### Improvements vs. `0.3.x`
+
+The `0.4.x` structures have significant advantages over the older structures.
+A dataset typically goes through the following 4-step life cycle. At each step,
+the new structures improve on the old.
+
+1. Populate the dataset with a list of projects obtained from a weblist, file,
+or other non-authoritative source.
+
+    The new structures include a custom `__eq__()` comparator that depends on
+    the previously-discussed `get_ids()` function and considers two structures
+    to be equal if:
+    
+    - they are of the same type,
+    - they share at least one id key, and
+    - they do not disagree on any values of shared id keys.
+
+    This provides a mechanism for merging projects/versions into an existing
+    list, something the older structures do not support.
+    
+2. Retrieve project/version data an authoritaive source (the registry API).
+ 
+    Separating out non-authoritative, editable information from data from
+    authoritative sources that should generally not be edited makes it much
+    clearer where the data came from and whether it can (should) be edited.
+    This also removes the possibility of accidentally overwriting a value from
+    a different source. For example, non-authoritative and authoritative sources
+    both commonly provide a `url` attribute, so storing them in separate
+    dictionaries avoids the possibility of one overwriting the other. 
+
+3. Manipulate the dataset.
+
+    Previous structures relied on a complex system of uuids that involved lambda
+    functions and could not be easily exported to json. As such, the json files
+    built using the `show` command could not be easily edited and re-imported.
+    Swapping to using jsonifiable dataclasses eliminates this problem, providing
+    much stronger support for exporting datasets to json, editing them, and
+    re-importing them.
+
+4. Export the dataset to an input set.
+
+    Previous structures relied on having a guaranteed set of attributes needed
+    for exporting a project/version pair to an input set item. This would then
+    fail if the guarantees were not met. The new structures replace this with a
+    more flexible system, allowing for invalid project/version pairs to be
+    exported if the user so desires.
+
+    This functionality is complemented with support for a more robust system for
+    logging warnings and errors, making it easier for users to quickly identify
+    invalid data in their datasets.

--- a/r2c_isg/structures/README.md
+++ b/r2c_isg/structures/README.md
@@ -18,9 +18,7 @@ registry-specific classes are as follows:
 These structures provide the following functionality: 
 
 - A `metadata` dictionary for storing data from authoritative sources, namely
-data obtained from a registry api. `keep([attrs...])` and `drop([attrs...])`
-utility functions are also provided to allow users to easily trim metadata down
-to only desired fields.
+data obtained from a registry api.
 - A `data` dictionary for storing data from non-authoritative sources such as
 files, weblists, and user-provided data.
 - A `get_ids()` function which returns a dictionary of name:value pairs of

--- a/r2c_isg/structures/core.py
+++ b/r2c_isg/structures/core.py
@@ -10,18 +10,11 @@ class BaseStructure(ABC):
     Version classes.
     """
 
-    @property
-    @abstractmethod
-    def id(self) -> Optional[str]:
-        """
-        The ID is the primary identifier of the structure. It is typically name
-        (for projects) or version (for versions), but this can be modified as
-        needed by BaseStructure's subclasses.
-        """
-        pass
+    # set by user or obtained from a weblist or other non-authoritative source
+    data: dict = field(default_factory=lambda: {}, repr=False)
 
-    id: str = field(default=id, init=False)
-    metadata: dict = field(default_factory=lambda: {}, repr=False)
+    # obtained from a registry api; should be treated as readonly
+    metadata: dict = field(default_factory=lambda: {}, repr=False, init=False)
 
     def keep(self, to_keep: List[str]):
         """???"""
@@ -32,11 +25,6 @@ class BaseStructure(ABC):
         """???"""
 
         pass
-
-    def _get_metadata(self, key: str) -> Optional[str]:
-        """Helper function to get a value from the metadata dict."""
-        val = self.metadata.get(key)
-        return val if isinstance(val, str) else None
 
 
 @dataclass
@@ -56,8 +44,10 @@ class Project(BaseStructure, ABC):
     It is extended by GenericProject, GithubRepo, NpmPackage, and PypiProject.
     """
 
+    # every project contains a list of versions
     versions: List[Version] = field(default_factory=lambda: [], repr=False)
 
     @abstractmethod
-    def to_inputset(self) -> dict:
+    def to_inputset(self, include_invalid: bool = False) -> list:
+        """Convert a project and its versions into a list of input set items."""
         pass

--- a/r2c_isg/structures/core.py
+++ b/r2c_isg/structures/core.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import List
 
 
 @dataclass
@@ -10,6 +10,11 @@ class BaseStructure(ABC):
     Version classes.
     """
 
+    @abstractmethod
+    def get_ids(self) -> dict:
+        """The unique identifiers of the structure."""
+        pass
+
     # set by user or obtained from a weblist or other non-authoritative source
     data: dict = field(default_factory=lambda: {}, repr=False)
 
@@ -18,26 +23,41 @@ class BaseStructure(ABC):
 
     def keep(self, to_keep: List[str]):
         """???"""
-
         pass
 
     def drop(self, to_drop: List[str]):
         """???"""
-
         pass
 
+    def __eq__(self, other):
+        # must be the same class type
+        if type(self) != type(other):
+            return False
 
-@dataclass
+        self_ids = self.get_ids()
+        other_ids = other.get_ids()
+
+        # must share at least one id
+        shared_ids = set(self_ids.keys()).intersection(set(other_ids.keys()))
+
+        for key in shared_ids:
+            # must not disagree on any shared ids
+            if self_ids[key] != other_ids[key]:
+                return False
+
+        return True if len(shared_ids) > 0 else False
+
+
+@dataclass(eq=False)
 class Version(BaseStructure, ABC):
     """
     A Version is an abstract class used to store all version-related data.
     It is extended by GenericVersion, GithubCommit, NpmVersion, and PypiRelease.
     """
-
     pass
 
 
-@dataclass
+@dataclass(eq=False)
 class Project(BaseStructure, ABC):
     """
     A Project is an abstract class used to store all project-related data.

--- a/r2c_isg/structures/core.py
+++ b/r2c_isg/structures/core.py
@@ -1,128 +1,63 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
 from typing import List, Optional
-from types import MethodType
 
 
-class Version(object):
-    def __init__(self, uuids_: dict = {}, meta_: dict = {}, **kwargs):
-        # set the uuid/meta functions as method types (to autopass self)
-        self.uuids_ = {}
-        for attr, func in uuids_.items():
-            self.uuids_[attr] = MethodType(func, self)
-        self.meta_ = {}
-        for attr, func in meta_.items():
-            self.meta_[attr] = MethodType(func, self)
+@dataclass
+class BaseStructure(ABC):
+    """
+    The Base Structure provides core functionality shared by the Project and
+    Version classes.
+    """
 
-        # load all attributes into the version
-        self.update(**kwargs)
-
-    def update(self, **kwargs) -> None:
-        """Populates the version with data from a dictionary."""
-        for k, val in kwargs.items():
-            setattr(self, k, val)
-
-        # make sure all guarantees are met
-        self.check_guarantees()
-
-    def check_guarantees(self) -> None:
-        """Guarantees nothing (vanilla Version knows nothing about its
-        contents)."""
+    @property
+    @abstractmethod
+    def id(self) -> Optional[str]:
+        """
+        The ID is the primary identifier of the structure. It is typically name
+        (for projects) or version (for versions), but this can be modified as
+        needed by BaseStructure's subclasses.
+        """
         pass
 
+    id: str = field(default=id, init=False)
+    metadata: dict = field(default_factory=lambda: {}, repr=False)
+
+    def keep(self, to_keep: List[str]):
+        """???"""
+
+        pass
+
+    def drop(self, to_drop: List[str]):
+        """???"""
+
+        pass
+
+    def _get_metadata(self, key: str) -> Optional[str]:
+        """Helper function to get a value from the metadata dict."""
+        val = self.metadata.get(key)
+        return val if isinstance(val, str) else None
+
+
+@dataclass
+class Version(BaseStructure, ABC):
+    """
+    A Version is an abstract class used to store all version-related data.
+    It is extended by GenericVersion, GithubCommit, NpmVersion, and PypiRelease.
+    """
+
+    pass
+
+
+@dataclass
+class Project(BaseStructure, ABC):
+    """
+    A Project is an abstract class used to store all project-related data.
+    It is extended by GenericProject, GithubRepo, NpmPackage, and PypiProject.
+    """
+
+    versions: List[Version] = field(default_factory=lambda: [], repr=False)
+
+    @abstractmethod
     def to_inputset(self) -> dict:
-        """Extracts input set relevant attributes from the version."""
-        # Note: The vanilla project is never used, even as a DefaultVersion.
-        # As such, this function should never be called. Instead, it's
-        # effectively an abstract method that child classes must implement.
-        raise Exception('Version class has no associated R2C input set type.')
-
-    def __eq__(self, other):
-        # the two versions are equal if one of the uuids matches
-        for k, val in self.uuids_.items():
-            if val() == other.uuids_[k]():
-                return True
-        return False
-
-    def __repr__(self):
-        # only return version identifiers
-        cls = str(type(self).__name__)
-        uuids = [str(func()) for _, func in self.uuids_.items()]
-        return '%s(%s)' % (cls, ', '.join(uuids))
-
-
-class Project(object):
-    def __init__(self, uuids_: dict = {}, meta_: dict = {}, **kwargs):
-        # a project contains versions
-        self.versions: List[Version] = []
-
-        # set the uuid/meta functions as method types (to autopass self)
-        self.uuids_ = {}
-        for attr, func in uuids_.items():
-            self.uuids_[attr] = MethodType(func, self)
-        self.meta_ = {}
-        for attr, func in meta_.items():
-            self.meta_[attr] = MethodType(func, self)
-
-        # load all attributes into the project
-        self.update(**kwargs)
-
-    def update(self, **kwargs) -> None:
-        """Populates the project with data from a dictionary."""
-        for k, val in kwargs.items():
-            setattr(self, k, val)
-
-        # make sure all guarantees are met
-        self.check_guarantees()
-
-    def check_guarantees(self) -> None:
-        """Guarantees nothing (vanilla Project knows nothing about its
-        contents)."""
         pass
-
-    def get_name(self) -> str:
-        """Returns the project's name."""
-        # child functions can override this to calculate the name--
-        # eg, extracting it from a url
-        return self.uuids_.get('name', '')
-
-    def find_version(self, **kwargs) -> Optional[Version]:
-        """Gets a version matching all kwargs or returns None."""
-
-        # build a temporary project containing the kwargs
-        this_v = Version(**kwargs)
-
-        # linear search function for now; potentially quite slow...
-        for other_v in self.versions:
-            # copy over the other project's uuid lambda funcs so the two
-            # projects can be compared (need to rebind the lambda func
-            # to this_p instead of other_p--hence the __func__ ref)
-            for k, func in other_v.uuids_.items():
-                this_v.uuids_[k] = MethodType(func.__func__, this_v)
-
-            if this_v == other_v:
-                return other_v
-
-        return None
-
-    def to_inputset(self) -> list:
-        """Vanilla project can't be converted to an r2c input set."""
-        # Note: The only time a vanilla Project is used is in the function
-        # Dataset.find_project(), which never calls to_inputset(). As such,
-        # this function should never be called. Instead, it's effectively
-        # an abstract method that child classes must implement.
-        raise Exception('Project class has no associated R2C input set type.')
-
-    def __eq__(self, other):
-        # the two projects are equal if one of the uuids matches
-        for k, val in self.uuids_.items():
-            if val() == other.uuids_[k]():
-                return True
-        return False
-
-    def __repr__(self):
-        # only return project identifiers
-        cls = str(type(self).__name__)
-        uuids = [str(func()) for _, func in self.uuids_.items()]
-        versions = [repr(v) for v in self.versions]
-        return '%s(%s, versions=[%s])' % (cls,
-                                          ', '.join(uuids),
-                                          ', '.join(versions))

--- a/r2c_isg/structures/core.py
+++ b/r2c_isg/structures/core.py
@@ -41,6 +41,13 @@ class BaseStructure(ABC):
 
         pass
 
+    def __post_init__(self):
+        if not self.get_ids():
+            # Give early warning that no ids means we can't compare structures.
+            # It's not the end of the world, but it limits functionality.
+            # TODO: log a warning
+            pass
+
     def __eq__(self, other):
         """
         Two structures are considered equal if:
@@ -55,6 +62,10 @@ class BaseStructure(ABC):
 
         self_ids = self.get_ids()
         other_ids = other.get_ids()
+        if not self_ids or not other_ids:
+            # can't effectively compare structures
+            # TODO: log a warning
+            pass
 
         shared_ids = set(self_ids.keys()).intersection(set(other_ids.keys()))
 

--- a/r2c_isg/structures/core.py
+++ b/r2c_isg/structures/core.py
@@ -12,24 +12,43 @@ class BaseStructure(ABC):
 
     @abstractmethod
     def get_ids(self) -> dict:
-        """The unique identifiers of the structure."""
+        """
+        A name:value dict of all the unique identifiers of the structure. For
+        most structures, ids will consist of some variant of name and url (for
+        projects) or version (for versions).
+
+        This function is used for:
+        1. Comparing structures. See `__eq__()` below for details.
+        2. Adding new projects/versions to existing project/version lists. See
+           the `load_...()` functions in the dataset for details.
+        """
+
         pass
 
     # set by user or obtained from a weblist or other non-authoritative source
     data: dict = field(default_factory=lambda: {}, repr=False)
 
     # obtained from a registry api; should be treated as readonly
-    metadata: dict = field(default_factory=lambda: {}, repr=False, init=False)
+    metadata: dict = field(default_factory=lambda: {}, init=False, repr=False)
 
     def keep(self, to_keep: List[str]):
         """???"""
+
         pass
 
     def drop(self, to_drop: List[str]):
         """???"""
+
         pass
 
     def __eq__(self, other):
+        """
+        Two structures are considered equal if:
+        1. they are of the same type,
+        2. they share at least one id key, and
+        3. they do not disagree on any values of shared id keys.
+        """
+
         # must be the same class type
         if type(self) != type(other):
             return False
@@ -37,7 +56,6 @@ class BaseStructure(ABC):
         self_ids = self.get_ids()
         other_ids = other.get_ids()
 
-        # must share at least one id
         shared_ids = set(self_ids.keys()).intersection(set(other_ids.keys()))
 
         for key in shared_ids:
@@ -45,15 +63,17 @@ class BaseStructure(ABC):
             if self_ids[key] != other_ids[key]:
                 return False
 
+        # must share at least one id
         return True if len(shared_ids) > 0 else False
 
 
 @dataclass(eq=False)
 class Version(BaseStructure, ABC):
     """
-    A Version is an abstract class used to store all version-related data.
-    It is extended by GenericVersion, GithubCommit, NpmVersion, and PypiRelease.
+    A Version is an abstract class used to store all version-related data. It is
+    extended by GenericVersion, GithubCommit, NpmVersion, and PypiRelease.
     """
+
     pass
 
 
@@ -69,5 +89,8 @@ class Project(BaseStructure, ABC):
 
     @abstractmethod
     def to_inputset(self, include_invalid: bool = False) -> list:
-        """Convert a project and its versions into a list of input set items."""
+        """
+        Convert a project and its versions into a list of input set items.
+        """
+
         pass

--- a/r2c_isg/structures/core.py
+++ b/r2c_isg/structures/core.py
@@ -31,16 +31,6 @@ class BaseStructure(ABC):
     # data obtained from an authoritative source (typically a registry api)
     metadata: dict = field(default_factory=lambda: {}, init=False, repr=False)
 
-    def keep(self, to_keep: List[str]):
-        """???"""
-
-        pass
-
-    def drop(self, to_drop: List[str]):
-        """???"""
-
-        pass
-
     def __post_init__(self):
         if not self.get_ids():
             # Give early warning that no ids means we can't compare structures.

--- a/r2c_isg/structures/core.py
+++ b/r2c_isg/structures/core.py
@@ -25,10 +25,10 @@ class BaseStructure(ABC):
 
         pass
 
-    # set by user or obtained from a weblist or other non-authoritative source
+    # data obtained from a non-authoritative source (user, file, weblist, etc.)
     data: dict = field(default_factory=lambda: {}, repr=False)
 
-    # obtained from a registry api; should be treated as readonly
+    # data obtained from an authoritative source (typically a registry api)
     metadata: dict = field(default_factory=lambda: {}, init=False, repr=False)
 
     def keep(self, to_keep: List[str]):

--- a/r2c_isg/structures/generic.py
+++ b/r2c_isg/structures/generic.py
@@ -1,18 +1,23 @@
-from r2c_isg.structures.core import Project
-from r2c_isg.structures.core import Version as GenericVersion
+from dataclasses import dataclass
+from typing import Optional
+
+from structures.core import Project, Version
 
 
+@dataclass
+class GenericVersion(Version):
+
+    @property
+    def id(self) -> Optional[str]:
+        return self._get_metadata('version')
+
+
+@dataclass
 class GenericProject(Project):
-    def check_guarantees(self) -> None:
-        """Guarantees a url."""
-        assert 'url' in self.uuids_, \
-            'Default project guarantees not met; ' \
-            'project url must be provided.'
 
-    def to_inputset(self) -> list:
-        """Converts default project to HttpUrl dict."""
-        self.check_guarantees()
-        return [{
-            'input_type': 'HttpUrl',
-            'url': self.uuids_['url']()
-        }]
+    @property
+    def id(self) -> Optional[str]:
+        return self._get_metadata('name') or self._get_metadata('url')
+
+    def to_inputset(self) -> dict:
+        pass

--- a/r2c_isg/structures/generic.py
+++ b/r2c_isg/structures/generic.py
@@ -2,22 +2,35 @@ from dataclasses import dataclass
 from typing import Optional
 
 from structures.core import Project, Version
+from util import get_str
 
 
 @dataclass
 class GenericVersion(Version):
 
     @property
-    def id(self) -> Optional[str]:
-        return self._get_metadata('version')
+    def version(self) -> Optional[str]:
+        return get_str('version', self.data) or None
 
 
 @dataclass
 class GenericProject(Project):
 
     @property
-    def id(self) -> Optional[str]:
-        return self._get_metadata('name') or self._get_metadata('url')
+    def name(self) -> Optional[str]:
+        return get_str('name', self.data) or None
 
-    def to_inputset(self) -> dict:
-        pass
+    @property
+    def url(self) -> Optional[str]:
+        return get_str('url', self.data) or None
+
+    def to_inputset(self, include_invalid: bool = False) -> list:
+        if not self.url and not include_invalid:
+            # skip this project
+            # TODO: log a warning...
+            return []
+
+        return [{
+            'input_type': 'HttpUrl',
+            'url': self.url,
+        }]

--- a/r2c_isg/structures/generic.py
+++ b/r2c_isg/structures/generic.py
@@ -1,28 +1,48 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 
 from structures.core import Project, Version
 from util import get_str
 
 
-@dataclass
+@dataclass(eq=False)
 class GenericVersion(Version):
+
+    def get_ids(self) -> dict:
+        ids = dict()
+        if self.version:
+            ids['version'] = self.version
+        return ids
 
     @property
     def version(self) -> Optional[str]:
         return get_str('version', self.data) or None
 
+    version: str = field(default=version, init=False)
 
-@dataclass
+
+@dataclass(eq=False)
 class GenericProject(Project):
+
+    def get_ids(self) -> dict:
+        ids = dict()
+        if self.name:
+            ids['name'] = self.name
+        if self.url:
+            ids['url'] = self.url
+        return ids
 
     @property
     def name(self) -> Optional[str]:
         return get_str('name', self.data) or None
 
+    name: str = field(default=name, init=False)
+
     @property
     def url(self) -> Optional[str]:
         return get_str('url', self.data) or None
+
+    url: str = field(default=url, init=False)
 
     def to_inputset(self, include_invalid: bool = False) -> list:
         if not self.url and not include_invalid:

--- a/r2c_isg/structures/github.py
+++ b/r2c_isg/structures/github.py
@@ -1,56 +1,33 @@
-from r2c_isg.structures.core import Project, Version
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+from structures.core import Project, Version
 
 
+@dataclass
 class GithubCommit(Version):
-    def check_guarantees(self) -> None:
-        """Guarantees a commit hash."""
-        assert 'commit' in self.uuids_, \
-            'Github commit guarantees not met; ' \
-            'commit hash must be provided.'
+
+    @property
+    def id(self) -> Optional[str]:
+        return self._get_metadata('sha')
+
+
+@dataclass
+class GithubRepo(Project):
+
+    def _name_from_url(self):
+        url = self._get_metadata('html_url') or ''
+
+        url_pattern = r'^.*github.com/(?P<name>[\w-]+/[\w-]+).*$'
+        match = re.match(url_pattern, url)
+
+        return match['name'] if match else None
+
+    @property
+    def id(self) -> Optional[str]:
+        return self._get_metadata('full_name') or self._name_from_url() or super().id
 
     def to_inputset(self) -> dict:
-        """Extracts input set relevant attributes from the commit."""
-        self.check_guarantees()
-        return {'commit_hash': self.uuids_['commit']()}
-
-
-class GithubRepo(Project):
-    def check_guarantees(self) -> None:
-        """Guarantees a name/org or a url."""
-        assert ('url' in self.uuids_ or (
-                'name' in self.uuids_ and 'org' in self.meta_)
-                ), 'Github repo guarantees not met; name/org or ' \
-                   'url must be provided.'
-
-    def get_name(self) -> str:
-        """Returns the project's name."""
-        if 'name' in self.uuids_:
-            return self.uuids_['name']()
-
-        # pull the name from the url
-        return self.uuids_['url']().strip('/').split('/')[-1]
-
-    def to_inputset(self) -> list:
-        """Converts github repos/commits to GitRepo/GitRepoCommit dict."""
-        self.check_guarantees()
-
-        if 'url' in self.uuids_:
-            url = self.uuids_['url']()
-        else:
-            # generate the url using the name/org
-            url = 'https://github.com/%s/%s' % (self.meta_['org'](),
-                                                self.uuids_['name']())
-
-        if len(self.versions) == 0:
-            # return input set type GitRepo
-            return [{
-                'input_type': 'GitRepo',
-                'repo_url': url
-            }]
-
-        # return input set type GitRepoCommit
-        return[{
-            'input_type': 'GitRepoCommit',
-            'repo_url': url,
-            **v.to_inputset()
-        } for v in self.versions]
+        url = f'https://github.com/{self.id}'
+        pass

--- a/r2c_isg/structures/github.py
+++ b/r2c_isg/structures/github.py
@@ -1,33 +1,89 @@
-import re
 from dataclasses import dataclass
 from typing import Optional
 
 from structures.core import Project, Version
+from util import get_str, name_from_url, url_from_name
 
 
 @dataclass
 class GithubCommit(Version):
 
     @property
-    def id(self) -> Optional[str]:
-        return self._get_metadata('sha')
+    def commit(self) -> Optional[str]:
+        return (
+            get_str('commit', self.data)
+            or get_str('sha', self.metadata)
+        ) or None
 
 
 @dataclass
 class GithubRepo(Project):
 
-    def _name_from_url(self):
-        url = self._get_metadata('html_url') or ''
+    @property
+    def url(self) -> Optional[str]:
+        url_literal = 'https://github.com/{name}'
 
-        url_pattern = r'^.*github.com/(?P<name>[\w-]+/[\w-]+).*$'
-        match = re.match(url_pattern, url)
+        org = get_str('org', self.data)
+        name = get_str('name', self.data)
+        data_fullname = f'{org}/{name}' if org and name else ''
 
-        return match['name'] if match else None
+        meta_fullname = get_str('full_name', self.metadata)
+
+        return (
+            get_str('url', self.data)
+            or url_from_name(name, url_literal) if '/' in name else None
+            or url_from_name(data_fullname, url_literal)
+            or get_str('html_url', self.metadata)
+            or url_from_name(meta_fullname, url_literal)
+        ) or None
 
     @property
-    def id(self) -> Optional[str]:
-        return self._get_metadata('full_name') or self._name_from_url() or super().id
+    def full_name(self) -> Optional[str]:
+        pattern: str = r'^.*github.com/(?P<name>[\w-]+/[\w-]+).*$'
 
-    def to_inputset(self) -> dict:
-        url = f'https://github.com/{self.id}'
-        pass
+        org = get_str('org', self.data)
+        name = get_str('name', self.data)
+        data_fullname = f'{org}/{name}' if org and name else None
+
+        data_url = get_str('url', self.data)
+        meta_url = get_str('html_url', self.metadata)
+
+        return (
+            name if '/' in name else None
+            or data_fullname
+            or name_from_url(data_url, pattern)
+            or get_str('full_name', self.metadata)
+            or name_from_url(meta_url, pattern)
+        ) or None
+
+    def to_inputset(self, include_invalid: bool = False) -> list:
+        if not self.url and not include_invalid:
+            # skip this project
+            # TODO: log a warning...
+            return []
+
+        if not self.versions:
+            return [{
+                'input_type': 'GitRepo',
+                'repo_url': self.url,
+            }]
+
+        inputs = []
+        for v in self.versions:
+            if not isinstance(v, GithubCommit):
+                # version is wrong object type
+                # TODO: log an exception...
+                continue
+
+            if not v.commit and not include_invalid:
+                # skip this version
+                # TODO: log a warning...
+                continue
+
+            inputs.append({
+                'input_type': 'GitRepoCommit',
+                'repo_url': self.url,
+                'commit_hash': v.commit,
+            })
+
+        return inputs

--- a/r2c_isg/structures/npm.py
+++ b/r2c_isg/structures/npm.py
@@ -1,45 +1,33 @@
-from r2c_isg.structures.core import Project, Version
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+from structures.core import Project, Version
 
 
+@dataclass
 class NpmVersion(Version):
-    def check_guarantees(self) -> None:
-        """Guarantees a version string."""
-        assert 'version' in self.uuids_, \
-            'Npm version guarantees not met; ' \
-            'version string must be provided.'
+
+    @property
+    def id(self) -> Optional[str]:
+        return self._get_metadata('version')
+
+
+@dataclass
+class NpmPackage(Project):
+
+    def _name_from_url(self):
+        url = self._get_metadata('url') or ''
+
+        url_pattern = r'^.*npmjs.com/package/(?P<name>[\w-]+).*$'
+        match = re.match(url_pattern, url)
+
+        return match['name'] if match else None
+
+    @property
+    def id(self) -> Optional[str]:
+        return self._get_metadata('name') or self._name_from_url()
 
     def to_inputset(self) -> dict:
-        """Extracts input set relevant attributes from the version."""
-        self.check_guarantees()
-        return {'version': self.uuids_['version']()}
-
-
-class NpmPackage(Project):
-    def check_guarantees(self) -> None:
-        """Guarantees a name or a url."""
-        assert 'name' in self.uuids_ or 'url' in self.uuids_, \
-            'Npm package guarantees not met; package name or ' \
-            'url must be provided.'
-
-    def get_name(self) -> str:
-        """Returns the project's name."""
-        if 'name' in self.uuids_:
-            return self.uuids_['name']()
-
-        # pull the name from the url
-        return self.uuids_['url']().strip('/').split('/')[-1]
-
-    def to_inputset(self) -> list:
-        """Converts npm packages/versions to PackageVersion dict."""
-        self.check_guarantees()
-
-        if not self.versions:
-            raise Exception('Npm package %s must contain at least one '
-                            'version before it can be exported to an '
-                            'input set.' % self.get_name())
-
-        return[{
-            'input_type': 'PackageVersion',
-            'package_name': self.get_name(),
-            **v.to_inputset()
-        } for v in self.versions]
+        url = f'https://npmjs.com/package/{self.id}'
+        pass

--- a/r2c_isg/structures/npm.py
+++ b/r2c_isg/structures/npm.py
@@ -1,33 +1,66 @@
-import re
 from dataclasses import dataclass
 from typing import Optional
 
 from structures.core import Project, Version
+from util import get_str, name_from_url, url_from_name
 
 
 @dataclass
 class NpmVersion(Version):
 
     @property
-    def id(self) -> Optional[str]:
-        return self._get_metadata('version')
+    def version(self) -> Optional[str]:
+        return (
+            get_str('version', self.data)
+            or get_str('version', self.metadata)
+        ) or None
 
 
 @dataclass
 class NpmPackage(Project):
 
-    def _name_from_url(self):
-        url = self._get_metadata('url') or ''
+    @property
+    def name(self) -> Optional[str]:
+        pattern = r'^.*npmjs.com/package/(?P<name>[\w-]+).*$'
 
-        url_pattern = r'^.*npmjs.com/package/(?P<name>[\w-]+).*$'
-        match = re.match(url_pattern, url)
-
-        return match['name'] if match else None
+        return (
+            get_str('name', self.data)
+            or name_from_url(get_str('url', self.data), pattern)
+            or get_str('name', self.metadata)
+        ) or None
 
     @property
-    def id(self) -> Optional[str]:
-        return self._get_metadata('name') or self._name_from_url()
+    def url(self) -> Optional[str]:
+        url_literal = 'https://npmjs.com/package/{name}'
 
-    def to_inputset(self) -> dict:
-        url = f'https://npmjs.com/package/{self.id}'
-        pass
+        return (
+            get_str('url', self.data)
+            or url_from_name(get_str('name', self.data), url_literal)
+            or url_from_name(get_str('name', self.metadata), url_literal)
+        ) or None
+
+    def to_inputset(self, include_invalid: bool = False) -> list:
+        if not self.name and not include_invalid:
+            # skip this project
+            # TODO: log a warning...
+            return []
+
+        inputs = []
+        for v in self.versions:
+            if not isinstance(v, NpmVersion):
+                # version is wrong object type
+                # TODO: log an exception...
+                continue
+
+            if not v.version and not include_invalid:
+                # skip this version
+                # TODO: log a warning...
+                continue
+
+            inputs.append({
+                'input_type': 'PackageVersion',
+                'package_name': self.name,
+                'version': v.version,
+            })
+
+        return inputs

--- a/r2c_isg/structures/npm.py
+++ b/r2c_isg/structures/npm.py
@@ -1,12 +1,18 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 
 from structures.core import Project, Version
 from util import get_str, name_from_url, url_from_name
 
 
-@dataclass
+@dataclass(eq=False)
 class NpmVersion(Version):
+
+    def get_ids(self) -> dict:
+        ids = dict()
+        if self.version:
+            ids['version'] = self.version
+        return ids
 
     @property
     def version(self) -> Optional[str]:
@@ -15,9 +21,19 @@ class NpmVersion(Version):
             or get_str('version', self.metadata)
         ) or None
 
+    version: str = field(default=version, init=False)
 
-@dataclass
+
+@dataclass(eq=False)
 class NpmPackage(Project):
+
+    def get_ids(self) -> dict:
+        ids = dict()
+        if self.name:
+            ids['name'] = self.name
+        if self.url:
+            ids['url'] = self.url
+        return ids
 
     @property
     def name(self) -> Optional[str]:
@@ -29,6 +45,8 @@ class NpmPackage(Project):
             or get_str('name', self.metadata)
         ) or None
 
+    name: str = field(default=name, init=False)
+
     @property
     def url(self) -> Optional[str]:
         url_literal = 'https://npmjs.com/package/{name}'
@@ -38,6 +56,8 @@ class NpmPackage(Project):
             or url_from_name(get_str('name', self.data), url_literal)
             or url_from_name(get_str('name', self.metadata), url_literal)
         ) or None
+
+    url: str = field(default=url, init=False)
 
     def to_inputset(self, include_invalid: bool = False) -> list:
         if not self.name and not include_invalid:

--- a/r2c_isg/structures/pypi.py
+++ b/r2c_isg/structures/pypi.py
@@ -1,12 +1,18 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 
 from structures.core import Project, Version
 from util import get_str, name_from_url, url_from_name
 
 
-@dataclass
+@dataclass(eq=False)
 class PypiRelease(Version):
+
+    def get_ids(self) -> dict:
+        ids = dict()
+        if self.version:
+            ids['version'] = self.version
+        return ids
 
     @property
     def version(self) -> Optional[str]:
@@ -15,9 +21,19 @@ class PypiRelease(Version):
             or get_str('version', self.metadata)
         ) or None
 
+    version: str = field(default=version, init=False)
 
-@dataclass
+
+@dataclass(eq=False)
 class PypiProject(Project):
+
+    def get_ids(self) -> dict:
+        ids = dict()
+        if self.name:
+            ids['name'] = self.name
+        if self.url:
+            ids['url'] = self.url
+        return ids
 
     @property
     def name(self) -> Optional[str]:
@@ -29,6 +45,8 @@ class PypiProject(Project):
             or get_str('name', self.metadata)
         ) or None
 
+    name: str = field(default=name, init=False)
+
     @property
     def url(self) -> Optional[str]:
         url_literal = 'https://pypi.org/project/{name}'
@@ -38,6 +56,8 @@ class PypiProject(Project):
             or url_from_name(get_str('name', self.data), url_literal)
             or url_from_name(get_str('name', self.metadata), url_literal)
         ) or None
+
+    url: str = field(default=url, init=False)
 
     def to_inputset(self, include_invalid: bool = False) -> list:
         if not self.name and not include_invalid:

--- a/r2c_isg/structures/pypi.py
+++ b/r2c_isg/structures/pypi.py
@@ -1,45 +1,33 @@
-from r2c_isg.structures.core import Project, Version
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+from structures.core import Project, Version
 
 
+@dataclass
 class PypiRelease(Version):
-    def check_guarantees(self) -> None:
-        """Guarantees a version string."""
-        assert 'version' in self.uuids_, \
-            'Pypi release guarantees not met; ' \
-            'version string must be provided.'
+
+    @property
+    def id(self) -> Optional[str]:
+        return self._get_metadata('version')
+
+
+@dataclass
+class PypiProject(Project):
+
+    def _name_from_url(self):
+        url = self._get_metadata('project_url') or ''
+
+        url_pattern = r'^.*pypi.org/project/(?P<name>[\w-]+).*$'
+        match = re.match(url_pattern, url)
+
+        return match['name'] if match else None
+
+    @property
+    def id(self) -> Optional[str]:
+        return self._get_metadata('name') or self._name_from_url()
 
     def to_inputset(self) -> dict:
-        """Extracts input set relevant attributes from the release."""
-        self.check_guarantees()
-        return {'version': self.uuids_['version']()}
-
-
-class PypiProject(Project):
-    def check_guarantees(self) -> None:
-        """Guarantees a name or a url."""
-        assert 'name' in self.uuids_ or 'url' in self.uuids_, \
-            'Pypi project guarantees not met; project name or ' \
-            'url must be provided.'
-
-    def get_name(self) -> str:
-        """Returns the project's name."""
-        if 'name' in self.uuids_:
-            return self.uuids_['name']()
-
-        # pull the name from the url
-        return self.uuids_['url']().strip('/').split('/')[-1]
-
-    def to_inputset(self) -> list:
-        """Converts pypi projects/releases to PackageVersion dict."""
-        self.check_guarantees()
-
-        if not self.versions:
-            raise Exception('Pypi project %s must contain at least one '
-                            'version before it can be exported to an '
-                            'input set.' % self.get_name())
-
-        return [{
-            'input_type': 'PackageVersion',
-            'package_name': self.get_name(),
-            **v.to_inputset()
-        } for v in self.versions]
+        url = f'https://pypi.org/project/{self.id}'
+        pass

--- a/r2c_isg/util.py
+++ b/r2c_isg/util.py
@@ -40,7 +40,7 @@ def name_from_url(url: str, pattern) -> Optional[str]:
 
 
 def url_from_name(name: str, url_literal) -> Optional[str]:
-    return url_literal.format(name) if name else None
+    return url_literal.format(name=name) if name else None
 
 
 def get_dataset(ctx):

--- a/r2c_isg/util.py
+++ b/r2c_isg/util.py
@@ -1,10 +1,10 @@
+import re
 import subprocess
 import traceback
+from typing import Optional
 
-from r2c_isg.dataset import Dataset
 
-
-def get_name():
+def get_name() -> Optional[str]:
     """Loads the default user name."""
 
     # only check git user.name for now
@@ -16,7 +16,7 @@ def get_name():
         return None
 
 
-def get_email():
+def get_email() -> Optional[str]:
     """Loads the default user email."""
 
     # only check git user.email for now
@@ -28,7 +28,22 @@ def get_email():
         return None
 
 
-def get_dataset(ctx) -> Dataset:
+def get_str(key: str, d: dict) -> str:
+    """Helper function to get a string value from a dict."""
+    val = d.get(key)
+    return val if isinstance(val, str) else ''
+
+
+def name_from_url(url: str, pattern) -> Optional[str]:
+    match = re.match(pattern, url)
+    return match['name'] if match else None
+
+
+def url_from_name(name: str, url_literal) -> Optional[str]:
+    return url_literal.format(name) if name else None
+
+
+def get_dataset(ctx):
     """Gets the dataset from the CLI context."""
     ds = ctx.obj.get('dataset', None)
 
@@ -48,3 +63,4 @@ def print_error(err: Exception, debug: bool = False) -> None:
 
     # print the error message
     print('         %s: %s' % (type(err).__name__, err))
+


### PR DESCRIPTION
My last few `version_0.4` PRs have contented themselves with rearranging, consolidating, and simplifying the project's structure without affecting functionality. Starting with this PR, I move from housecleaning to remodeling.

When I released the first working version of ISG last year, I knew I wasn't content with some of the design decisions I'd made with respect to the `Project` and `Version` classes. I'd built them quite early on in the project, as they were foundational to the operation of the dataset, data loaders, and APIs. Unfortunately, this meant that the structures were, to some extent, already locked in place even as my understanding of the project evolved and improved.

As a prime example, I didn't realize how much users would rely on exporting the dataset to json, editing it, and re-importing it as a way to tweak parameters and fix invalid data. (It seems so obvious in retrospect!) The existing structures, with their lambda function-driven uuids, require substantial gymnastics to export to/from json. They just aren't built to do that. There are several more examples of these sorts of failings; I refer you to the README below.

With the benefit of 6 months of user feedback and thought, I now propose a completely overhauled set of structures which should meet our common use cases more readily and provide more flexibility for future revisions/improvements. Since the structures are so core to the functioning of the ISG, **this will break everything**. Hence the `version_0.4` branch instead of merging into `master`. In the coming days, I plan to submit additional PRs to revise the dataset, data loaders, and APIs to accommodate these changes.